### PR TITLE
[cxxCompressor] fix subprocess OSError by using absolute path to exe

### DIFF
--- a/compreffor/cxxCompressor.py
+++ b/compreffor/cxxCompressor.py
@@ -204,7 +204,7 @@ def compreff(font, verbose=False, use_lib=False, **kwargs):
         print("Preparing external call...")
         start_time = time.time()
 
-    call = [os.path.join(os.path.dirname(__file__), "cffCompressor")]
+    call = [os.path.join(os.path.abspath(os.path.dirname(__file__)), "cffCompressor")]
 
     if 'nrounds' in kwargs and kwargs.get('nrounds') != None:
         call.extend(['--nrounds', str(kwargs.get('nrounds'))])


### PR DESCRIPTION
Using Homebrew Python 2.7.9 on OS X, subprocess can't find the path to the `cffCompressor` executable since it is not in the environment $PATH. It works if you pass the full absolute path.

```python
Traceback (most recent call last):
  File "cxxCompressor.py", line 388, in <module>
    main(**kwargs)
  File "cxxCompressor.py", line 343, in main
    handle_font(filename)
  File "cxxCompressor.py", line 317, in handle_font
    compreff(font, verbose=verbose, **comp_kwargs)
  File "cxxCompressor.py", line 234, in compreff
    stdout=subprocess.PIPE)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```