### PR TITLE
fix compreffor to work with latest fontTools

### DIFF
--- a/compreffor/cxxCompressor.py
+++ b/compreffor/cxxCompressor.py
@@ -306,7 +306,7 @@ def main(filename=None, comp_fname=None, test=False, decompress=False,
             if decompress:
                 from fontTools import subset
                 options = subset.Options()
-                options.decompress = True
+                options.desubroutinize = True
                 subsetter = subset.Subsetter(options=options)
                 subsetter.populate(glyphs=font.getGlyphOrder())
                 subsetter.subset(font)

--- a/compreffor/pyCompressor.py
+++ b/compreffor/pyCompressor.py
@@ -1034,7 +1034,7 @@ def main(filename=None, comp_fname=None, test=False, decompress=False,
             if decompress:
                 from fontTools import subset
                 options = subset.Options()
-                options.decompress = True
+                options.desubroutinize = True
                 subsetter = subset.Subsetter(options=options)
                 subsetter.populate(glyphs=font.getGlyphOrder())
                 subsetter.subset(font)

--- a/compreffor/pyCompressor.py
+++ b/compreffor/pyCompressor.py
@@ -531,7 +531,7 @@ class Compreffor(object):
             assert len(lsubrs) == 1
 
             if not hasattr(top_dict.Private, "Subrs"):
-                fd.Private.Subrs = cffLib.SubrsIndex()
+                top_dict.Private.Subrs = cffLib.SubrsIndex()
             for subr in lsubrs[0]:
                 item = psCharStrings.T2CharString(program=subr._program)
                 top_dict.Private.Subrs.append(item)

--- a/compreffor/pyCompressor.py
+++ b/compreffor/pyCompressor.py
@@ -266,7 +266,7 @@ class SubstringFinder(object):
         next_key = 0
 
         for k in self.glyph_set_keys:
-            char_string = glyph_set[k]
+            char_string = glyph_set[k]._glyph
             char_string.decompile()
             program = []
             piter = iter(enumerate(char_string.program))

--- a/compreffor/pyCompressor.py
+++ b/compreffor/pyCompressor.py
@@ -271,9 +271,8 @@ class SubstringFinder(object):
             program = []
             piter = iter(enumerate(char_string.program))
             for i, tok in piter:
-                assert tok not in ("callsubr", "callgsubr", "return", "endchar") or \
-                       tok in ("callsubr", "callgsubr", "return", "endchar") and \
-                            i == len(char_string.program) - 1
+                assert tok not in ("callsubr", "callgsubr", "return")
+                assert tok != "endchar" or i == len(char_string.program) - 1
                 if tok in ("hintmask", "cntrmask"):
                     # Attach next token to this, as a subroutine
                     # call cannot be placed between this token and

--- a/compreffor/testPyCompressor.py
+++ b/compreffor/testPyCompressor.py
@@ -270,8 +270,10 @@ def test_compression_integrity(orignal_file, compressed_file):
 
     passed = True
     for g in orig_gset.keys():
-        orig_gset[g].decompile()
-        if not (orig_gset[g].program == comp_gset[g].program):
+        orig_glyph = orig_gset[g]._glyph
+        comp_glyph = comp_gset[g]._glyph
+        orig_glyph.decompile()
+        if not (orig_glyph.program == comp_glyph.program):
             print "Difference found in glyph '%s'" % (g,)
             passed = False
 

--- a/compreffor/testPyCompressor.py
+++ b/compreffor/testPyCompressor.py
@@ -262,7 +262,7 @@ def test_compression_integrity(orignal_file, compressed_file):
 
     # decompress the compressed font
     options = fontTools.subset.Options()
-    options.decompress = True
+    options.desubroutinize = True
     subsetter = fontTools.subset.Subsetter(options=options)
     subsetter.populate(glyphs=comp_font.getGlyphOrder())
     subsetter.subset(orig_font)


### PR DESCRIPTION
the reason why my test fonts in issue https://github.com/googlei18n/compreffor/issues/2 were not correctly processed by compreffor was because the "decompress" option from fontTools' subsetter has been recently renamed "desubroutinize", so the '-d' command line option in compreffor was not actually doing the decompression, hance the assertion error.
So I renamed all occurrences of `options.decompress` to `options.desubroutinize`.
I also made sure the '_glyph' attribute is used for accessing the wrapped T2CharString instance.
Finally, I fixed a variable referenced before assignment.
Cheers,

Cosimo