### PR TITLE
build executable and shared lib using setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include setup.py
+include LICENSE
+include README.md
+exclude compreffor/cffCompressor
+exclude compreffor/cffCompressor.exe
+exclude compreffor/compreff.dll
+exclude compreffor/libcompreff.so
+recursive-include compreffor *.py
+recursive-include tools *.py
+recursive-include cxx-src *.cc *.h
+include cxx-src/Makefile

--- a/compreffor/cxxCompressor.py
+++ b/compreffor/cxxCompressor.py
@@ -195,7 +195,7 @@ def interpret_data(td, results):
 
     return (subrs, glyph_encodings)
 
-def compreff(font, verbose=False, use_lib=False, **kwargs):
+def compreff(font, verbose=False, use_lib=True, **kwargs):
     """Main function that compresses `font`, a TTFont object,
     in place. All heavy lifting is passed off either to an
     executable or shared library based on the use_lib argument."""

--- a/compreffor/cxxCompressor.py
+++ b/compreffor/cxxCompressor.py
@@ -46,6 +46,11 @@ from compreffor.testPyCompressor import (
 from fontTools.misc.py23 import BytesIO
 from fontTools.ttLib import TTFont
 
+if sys.platform == 'win32':
+    LIB_NAME = 'compreff.dll'
+else:
+    LIB_NAME = 'libcompreff.so'
+
 # default values:
 NSUBRS_LIMIT = 65533
 SUBR_NEST_LIMIT  = 10
@@ -215,7 +220,7 @@ def compreff(font, verbose=False, use_lib=False, **kwargs):
         max_subrs = kwargs.get('nsubrs_limit')
 
     if use_lib:
-        lib_path = os.path.join(os.path.dirname(__file__), "libcompreff.so")
+        lib_path = os.path.join(os.path.dirname(__file__), LIB_NAME)
         libcompreff = ctypes.CDLL(lib_path)
         libcompreff.compreff.restype = ctypes.POINTER(ctypes.c_uint32)
         input_data = ctypes.c_char_p(write_data(td))

--- a/cxx-src/Makefile
+++ b/cxx-src/Makefile
@@ -7,14 +7,29 @@ CC = g++
 DEPS = cffCompressor.h
 BIN = ../compreffor
 
-all: cffCompressor lib
-cffCompressor: cffCompressor.o
-	$(CC) $(CXXFLAGS) -o $(BIN)/$@ $^
+ifeq ($(OS),Windows_NT)
+    uname_S := Windows
+else
+    uname_S := $(shell uname -s)
+endif
+ifeq ($(uname_S), Windows)
+    executable = cffCompressor.exe
+    sharedlib = compreff.dll
+    # statically link libgcc, libstdc++ and libwinpthread on mingw-w64
+    LDFLAGS ?= -static
+else
+    executable = cffCompressor
+    sharedlib = libcompreff.so
+endif
+
+all: $(executable) lib
+$(executable): cffCompressor.o
+	$(CC) $(CXXFLAGS) -o $(BIN)/$@ $(LDFLAGS) $^
 %.o: %.cc $(DEPS)
 	$(CC) $(CXXFLAGS) -o $@ -c -O$(O) $<
-lib: libcompreff.so
-libcompreff.so: cffCompressor.cc $(DEPS)
-	$(CC) $(CXXSOFLAGS) -o $(BIN)/$@ -O$(O) -fPIC $<
+lib: $(sharedlib)
+$(sharedlib): cffCompressor.cc $(DEPS)
+	$(CC) $(CXXSOFLAGS) -o $(BIN)/$@ -O$(O) -fPIC $(LDFLAGS) $<
 clean:
-	rm -f cffCompressor.o cffCompressor libcompreff.so
+	rm -rf cffCompressor.o $(BIN)/$(executable) $(BIN)/$(sharedlib) $(BIN)/$(sharedlib).dSYM
 ALL: clean all

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,83 @@
 #!/usr/bin/env python
 from __future__ import print_function
 from setuptools import setup
+from distutils.command.build import build
+from distutils.command.install_lib import install_lib
+from distutils.command.clean import clean
+from distutils.cmd import Command
+import sys
+import os
+import subprocess
 
 try:
     import fontTools
 except:
     print("*** Warning: compreffor requires fontTools, see:")
     print("    https://github.com/behdad/fonttools")
+
+CURR_DIR = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+CXX_SOURCES = os.path.join(CURR_DIR, 'cxx-src')
+
+# platform-specific executable name
+EXE_NAME = 'cffCompressor'
+if sys.platform == 'win32':
+    EXE_NAME += '.exe'
+
+# platform-specific shared library name
+if sys.platform == 'win32':
+    LIB_NAME = 'compreff.dll'
+else:
+    LIB_NAME = 'libcompreff.so'
+
+# make sure 'build_cxx' is called as part of 'build' command
+build.sub_commands.insert(0, ('build_cxx', lambda *a: True))
+
+
+class BuildCXX(Command):
+    description = "Build 'compreffor' C++ executable and shared library."
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        subprocess.check_call(['make'], cwd=CXX_SOURCES)
+        executable = os.path.join(CXX_SOURCES, "..", "compreffor", EXE_NAME)
+        library = os.path.join(CXX_SOURCES, "..", "compreffor", LIB_NAME)
+        assert os.path.exists(executable)
+        assert os.path.exists(library)
+        build_py = self.get_finalized_command('build_py')
+        dest = os.path.join(build_py.build_lib, 'compreffor')
+        self.mkpath(dest)
+        self.copy_file(executable, dest)
+        self.copy_file(library, dest)
+
+
+class CleanCommand(clean):
+
+    user_options = clean.user_options + [
+        ('cxx', None, "run 'make clean' to remove C++ build output")
+    ]
+
+    def initialize_options(self):
+        clean.initialize_options(self)
+        self.cxx = None
+
+    def run(self):
+        clean.run(self)
+        if self.cxx or self.all:
+            subprocess.check_call(['make', 'clean'], cwd=CXX_SOURCES)
+
+
+class InstallLibCommand(install_lib):
+
+    def build(self):
+        install_lib.build(self)
+        if not self.skip_build:
+            self.run_command('build_cxx')
 
 
 setup(
@@ -16,4 +87,11 @@ setup(
     author="Sam Fishman",
     license="Apache 2.0",
     packages=["compreffor"],
+    package_data={"compreffor": [EXE_NAME, LIB_NAME]},
+    cmdclass={
+           'build_cxx': BuildCXX,
+           'clean': CleanCommand,
+           'install_lib': InstallLibCommand,
+        },
+    zip_safe=False,
 )


### PR DESCRIPTION
This is just temporary, until we make a true Python extension module (i'm thinking of using Cython for that).

The build still requires GNU `make` and a unix compiler, so to make it work on Windows one needs to use the mingw-w64 gcc from an [MSYS2](https://msys2.github.io/) environment.

At least this allows to run `python setup.py build` or `python setup.py install` (or `pip install`, etc.) and have `make`  run automatically as a subprocess.

I installed MSYS2, then installed the 32-bit toolchain with `pacman -S mingw-w64-i686-toolchain` and built the `cffCompressor.exe` and `compreff.dll` (the names are a bit inconsistent, btw).

When running compreffor using the executable (with `compreff(font, use_lib=False)`), the executable crashes with `std::bad_alloc`... We need to further investigate this. However, when running with the shared library loaded through `ctypes` (by setting `use_lib=True`), then it seems to be working fine.
So, I decided to make `use_lib=True` the default. Non-windows users can set `use_lib=False` if that speeds it up (I haven't tested).

Please take a look, thanks.
