### PR TITLE
fixes for Visual Studio

### DIFF
--- a/compreffor/__init__.py
+++ b/compreffor/__init__.py
@@ -82,6 +82,19 @@ extension. Example usage:
 
 from compreffor import cxxCompressor, pyCompressor
 import os
+import sys
+
+
+# platform-specific executable name
+EXE_NAME = 'cffCompressor'
+if sys.platform == 'win32':
+    EXE_NAME += '.exe'
+
+# platform-specific shared library name
+if sys.platform == 'win32':
+    LIB_NAME = 'compreff.dll'
+else:
+    LIB_NAME = 'libcompreff.so'
 
 
 class Methods:
@@ -92,8 +105,8 @@ class Compreffor(object):
         self.font = font
         self.method = method
         self.options = options
-        self.exe_path = os.path.join(os.path.dirname(__file__), "cffCompressor")
-        self.lib_path = os.path.join(os.path.dirname(__file__), "libcompreff.so")
+        self.exe_path = os.path.join(os.path.dirname(__file__), EXE_NAME)
+        self.lib_path = os.path.join(os.path.dirname(__file__), LIB_NAME)
 
     def compress(self):
         if self.method == Methods.NoPref:

--- a/compreffor/cxxCompressor.py
+++ b/compreffor/cxxCompressor.py
@@ -195,7 +195,7 @@ def interpret_data(td, results):
 
     return (subrs, glyph_encodings)
 
-def compreff(font, verbose=False, use_lib=True, **kwargs):
+def compreff(font, verbose=False, use_lib=False, **kwargs):
     """Main function that compresses `font`, a TTFont object,
     in place. All heavy lifting is passed off either to an
     executable or shared library based on the use_lib argument."""

--- a/cxx-src/Makefile.vc
+++ b/cxx-src/Makefile.vc
@@ -1,0 +1,34 @@
+CXXFLAGS = /nologo /O2 /EHsc /Zi
+BIN = ..\compreffor
+
+SRC_NAME = cffCompressor
+LIB_NAME = compreff
+
+TARGET_EXE = $(BIN)\$(SRC_NAME).exe
+TARGET_DLL = $(BIN)\$(LIB_NAME).dll
+
+all: exe dll
+
+exe: $(TARGET_EXE)
+
+$(TARGET_EXE): $(SRC_NAME).obj
+	$(CXX) $(CXXFLAGS) /Fe$@ $(SRC_NAME).obj
+
+$(SRC_NAME).obj: $(SRC_NAME).cc $(SRC_NAME).h
+	$(CXX) $(CXXFLAGS) /c $(SRC_NAME).cc
+
+dll: $(TARGET_DLL)
+
+$(TARGET_DLL): $(SRC_NAME).cc $(SRC_NAME).h
+	$(CXX) $(CXXFLAGS) /Fe$@ $(SRC_NAME).cc /LD /link /DEF:$(LIB_NAME).def
+
+clean:
+	@-if exist $(SRC_NAME).obj del /f /q $(SRC_NAME).obj
+	@-if exist $(TARGET_EXE) del /f /q $(TARGET_EXE)
+	@-if exist $(BIN)\$(SRC_NAME).ilk del /f /q $(BIN)\$(SRC_NAME).ilk
+	@-if exist $(BIN)\$(SRC_NAME).pdb del /f /q $(BIN)\$(SRC_NAME).pdb
+	@-if exist $(TARGET_DLL) del /f /q $(TARGET_DLL)
+	@-if exist $(BIN)\$(LIB_NAME).exp del /f /q $(BIN)\$(LIB_NAME).exp
+	@-if exist $(BIN)\$(LIB_NAME).lib del /f /q $(BIN)\$(LIB_NAME).lib
+	@-if exist $(BIN)\$(LIB_NAME).ilk del /f /q $(BIN)\$(LIB_NAME).ilk
+	@-if exist $(BIN)\$(LIB_NAME).pdb del /f /q $(BIN)\$(LIB_NAME).pdb

--- a/cxx-src/cffCompressor.cc
+++ b/cxx-src/cffCompressor.cc
@@ -16,6 +16,12 @@
 
 #include "cffCompressor.h"
 
+// needed for Windows's "_setmode" to enable binary mode for stdin/stdout
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 const unsigned int_size = sizeof(int_type);
 const float K = 0.1;
 const float ALPHA = 0.1;
@@ -1116,6 +1122,17 @@ int main(int argc, const char* argv[]) {
       return 1;
     }
   }
+
+#ifdef _WIN32
+  if (_setmode(_fileno(stdin), _O_BINARY) == -1) {
+    std::cerr << "Cannot set stdin to binary mode" << std::endl;
+    return 1;
+  }
+  if (_setmode(_fileno(stdout), _O_BINARY) == -1) {
+    std::cerr << "Cannot set stdout to binary mode" << std::endl;
+    return 1;
+  }
+#endif
 
   charstring_pool_t csPool = CharstringPoolFactory(
                                       std::cin,

--- a/cxx-src/cffCompressor.cc
+++ b/cxx-src/cffCompressor.cc
@@ -728,12 +728,13 @@ void charstring_pool_t::addRawCharstring(unsigned char* data, unsigned len) {
       }
     }
 
-    unsigned char rawTok[tokSize];
+    unsigned char* rawTok = new unsigned char[tokSize];
     rawTok[0] = first;
     memcpy(rawTok + 1, data + csPos + 1, tokSize - 1);
     csPos += (tokSize - 1);
 
     addRawToken(rawTok, tokSize);
+    delete[] rawTok;
 
     ++nToks;
   }
@@ -986,7 +987,7 @@ charstring_pool_t CharstringPoolFactory(
 
   uint32_t* offset = new uint32_t[count + 1];
 
-  unsigned char offsetBuffer[(count + 1) * offSize];
+  unsigned char* offsetBuffer = new unsigned char[(count + 1) * offSize];
   instream.read(reinterpret_cast<char*>(offsetBuffer), (count + 1) * offSize);
   for (int i = 0; i < count + 1; ++i) {
     offset[i] = 0;
@@ -995,6 +996,7 @@ charstring_pool_t CharstringPoolFactory(
     }
     offset[i] -= 1;  // CFF is 1-indexed(-ish)
   }
+  delete[] offsetBuffer;
   assert(offset[0] == 0);
 
   charstring_pool_t csPool(count, numRounds);

--- a/cxx-src/compreff.def
+++ b/cxx-src/compreff.def
@@ -1,0 +1,4 @@
+LIBRARY   compreff
+EXPORTS
+   compreff   @1
+   unload     @2


### PR DESCRIPTION
- must set stdin/stdout in binary mode on Windows, or the newlines, EOF chars, etc. get messed up;
- Visual C++ does not support variable length arrays, so we use new/delete[] instead;
- add Makefile.vc for Vistul Studio's `nmake.exe`. I only tested it with Visual Studio 2013 and 2015, which have C++11 support (required for `std::thread`). To build the executable and the shared library, launch the Visual Studio command prompt and do:

```
$ cd cxx-src
$ nmake -f Makefile.vc
```
- use a `.def` file when linking `compreff.dll` containing the exported functions (otherwise `ctypes` cannot load any functions from the MSVC-built dll).

Again, this is all just temporary, until we figure out a more pythonic way to wrap the C++ stuff.