### PR TITLE
setup.py: use '-std=c++0x' instead of '-std=c++11'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ extensions = [
         depends=[os.path.join('cxx-src', 'cffCompressor.h')],
         extra_compile_args={
             "default": [
-                "-std=c++11", "-pthread",
+                "-std=c++0x", "-pthread",
                 "-Wextra", "-Wno-unused", "-Wno-unused-parameter",
                 # pass extra compiler flags on OS X to enable support for C++11
             ] + (["-stdlib=libc++", "-mmacosx-version-min=10.7"]


### PR DESCRIPTION
This allows to compile compreffor on Travis CI's containers without needing to update GCC.
The two options should do the same thing.

Fixes https://github.com/googlei18n/fontmake/pull/121

Note: before we made the Cython wrapper, we were using `make` to build the shared library, and the Makefile has `-std=c++0x` instead of `-std=c++11` and it was working just fine.