### PR TITLE
cffCompressor.cc: use std::thread::hardware_concurrency() for NUM_THREADS

### DIFF
--- a/src/cxx/cffCompressor.cc
+++ b/src/cxx/cffCompressor.cc
@@ -25,7 +25,8 @@
 const unsigned int_size = sizeof(int_type);
 const float K = 0.1;
 const float ALPHA = 0.1;
-const unsigned NUM_THREADS = 100;
+const unsigned hardware_threads = std::thread::hardware_concurrency();
+const unsigned NUM_THREADS = hardware_threads != 0 ? hardware_threads : 1;
 const unsigned DEFAULT_NUM_ROUNDS = 4;
 
 // token_t ============

--- a/src/cxx/cffCompressor.cc
+++ b/src/cxx/cffCompressor.cc
@@ -26,7 +26,7 @@ const unsigned int_size = sizeof(int_type);
 const float K = 0.1;
 const float ALPHA = 0.1;
 const unsigned hardware_threads = std::thread::hardware_concurrency();
-const unsigned NUM_THREADS = hardware_threads != 0 ? hardware_threads : 1;
+const unsigned NUM_THREADS = hardware_threads ? hardware_threads : 1;
 const unsigned DEFAULT_NUM_ROUNDS = 4;
 
 // token_t ============


### PR DESCRIPTION
The current default value is set to 100, which is too large and results in 'oversubscription' (i.e. number of threads exceeding available logical cores).
That means the workload is decomposed into too small chunks, leading to unnecessary 'context switching' of the CPU from one thread to another, that can slow the overall performace.

The `hardware_concurrency` function returns the number of hardware threads available on the system (e.g. CPU cores or hyperthreading units), or 0 if the information is not available.

http://www.cplusplus.com/reference/thread/thread/hardware_concurrency/

I'm new to both C++ and multi-threading, so any suggestions or comments are appreciated,
thanks!