### PR TITLE
Refactor in preparation for PyPI deployment 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ with open('README.rst', 'r') as f:
 
 setup_params = dict(
     name="compreffor",
-    version="0.3.0",
+    version="0.4.0.dev0",
     description="A CFF subroutinizer for fontTools.",
     long_description=long_description,
     author="Sam Fishman",
@@ -175,6 +175,11 @@ setup_params = dict(
     install_requires=[
         "fonttools>=3.1",
     ],
+    entry_points={
+        'console_scripts': [
+            "compreffor = compreffor.__main__:main",
+        ]
+    },
     zip_safe=False,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -69,6 +69,12 @@ extension. Example usage:
 # font written to /path/to/font.compressed.otf
 """
 
+import logging
+from fontTools.misc.loggingTools import Timer
+
+log = logging.getLogger(__name__)
+timer = Timer(logger=logging.getLogger(log.name + ".timer"))
+
 from compreffor import cxxCompressor, pyCompressor
 
 
@@ -78,7 +84,8 @@ def compress(ttFont, method_python=False, **options):
     If the font already contains subroutines, it is first decompressed.
     """
     if has_subrs(ttFont):
-        # there are subroutines in font; must decompress it first
+        log.warning(
+            "There are subroutines in font; must decompress it first")
         decompress(ttFont)
     if method_python:
         pyCompressor.compreff(ttFont, **options)
@@ -92,7 +99,8 @@ def decompress(ttFont, **kwargs):
     Skip if the font contains no subroutines.
     """
     if not has_subrs(ttFont):
-        return  # Nothing to decompress
+        log.debug('No subroutines found; skip decompress')
+        return
 
     from fontTools import subset
 

--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -81,7 +81,7 @@ def compress(ttFont, method_python=False, **options):
         # there are subroutines in font; must decompress it first
         decompress(ttFont)
     if method_python:
-        pyCompressor.Compreffor(ttFont, **options).compress()
+        pyCompressor.compreff(ttFont, **options)
     else:
         cxxCompressor.compreff(ttFont, **options)
 

--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -134,6 +134,19 @@ def has_subrs(ttFont):
     return len(td.GlobalSubrs) > 0 or priv_subrs
 
 
+def check(original_file, compressed_file):
+    """ Compare the original and compressed font files to confirm they are
+    functionally equivalent. Also check that the Charstrings in the compressed
+    font's CFFFontSet don't exceed the maximum subroutine nesting level.
+    Return True if all checks pass, else return False.
+    """
+    from compreffor.test.util import check_compression_integrity
+    from compreffor.test.util import check_call_depth
+    rv = check_compression_integrity(original_file, compressed_file)
+    rv &= check_call_depth(compressed_file)
+    return rv
+
+
 # The `Methods` and `Compreffor` classes are now deprecated, but we keep
 # them here for backward compatibility
 

--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -72,27 +72,37 @@ extension. Example usage:
 from compreffor import cxxCompressor, pyCompressor
 
 
+def compress(ttFont, method_python=False, **options):
+    """ Subroutinize TTFont instance in-place using the C++ Compreffor.
+    If 'method_python' is True, use the slower, pure-Python Compreffor.
+    """
+    if method_python:
+        pyCompressor.Compreffor(ttFont, **options).compress()
+    else:
+        cxxCompressor.compreff(ttFont, **options)
+
+
+# The `Methods` and `Compreffor` classes are now deprecated, but we keep
+# them here for backward compatibility
+
+
 class Methods:
     Py, Cxx = range(2)
 
 
 class Compreffor(object):
     def __init__(self, font, method=Methods.Cxx, **options):
+        import warnings
+        warnings.warn("'Compreffor' class is deprecated; use 'compress' function "
+                      "instead", UserWarning)
         self.font = font
         self.method = method
         self.options = options
 
     def compress(self):
         if self.method == Methods.Py:
-            self.run_py()
+            compress(self.font, method_python=True, **self.options)
         elif self.method == Methods.Cxx:
-            self.run_cxx()
+            compress(self.font, method_python=False, **self.options)
         else:
             raise ValueError("Invalid method: %r" % self.method)
-
-    def run_py(self):
-        compreffor = pyCompressor.Compreffor(self.font, **self.options)
-        compreffor.compress()
-
-    def run_cxx(self):
-        cxxCompressor.compreff(self.font, **self.options)

--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -75,7 +75,11 @@ from compreffor import cxxCompressor, pyCompressor
 def compress(ttFont, method_python=False, **options):
     """ Subroutinize TTFont instance in-place using the C++ Compreffor.
     If 'method_python' is True, use the slower, pure-Python Compreffor.
+    If the font already contains subroutines, it is first decompressed.
     """
+    if has_subrs(ttFont):
+        # there are subroutines in font; must decompress it first
+        decompress(ttFont)
     if method_python:
         pyCompressor.Compreffor(ttFont, **options).compress()
     else:

--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -21,52 +21,42 @@ outputted font file. In addition to providing a Python
 interface, this tool can be used on the command line.
 
 Usage (python):
+>> from fontTools.ttLib import TTFont
+>> import compreffor
 >> font = TTFont(filename)
 >> options = { ... }
->> comp = Compreffor(font, method=compreffor.Methods.Cxx, **options)
->> comp.compress()
+>> compreffor.compress(font, **options)
 >> font.save(filename)
-
-Options:
-When initializing a Compreffor object, options can be set using
-the options kwargs. They are:
-    - verbose (boolean) -- print status messages during compression
-    - nrounds (integer) -- the number of market iterations to run
-    - nsubrs_limit (integer) -- limit to number of subrs per INDEX
-With Methods.Py, the following additional options are available:
-    - print_status (boolean) -- printing level lower than verbose
-    - chunk_ratio (float) -- set the percentage of charstrings
-                             to be run by each process
-    - single_process (boolean) -- disable multiprocessing
-    - processes (integer) -- the number of simultaneous processes
-                             to run
 
 Compression Backends:
 There are 2 different ways the compreffor can be run.
-    - First is a pure python approach, which can be selected from this module
-      by passing method=Methods.Py. This backend is significantly slower than
-      the other backend (~10-20x). The logic for this backend can be found
-      in pyCompressor.py.
-    - Second is C++ extension module backed. With this method, python calls
-      the relevant functions by importing directly from `_compreffor.so`. This
-      is the default method=Methods.Cxx. The logic is in cxxCompressor.py,
-      cffCompressor.h, cffCompressor.cc and _compreffor.pyx.
+    - The default method is backed by a C++ extension module. The logic is
+      in cxxCompressor.py, cffCompressor.h, cffCompressor.cc and
+      _compreffor.pyx.
+    - The second is a pure Python approach, and can be selected from `compress`
+      by passing `method_python=True`. This is significantly slower than the
+      the other backend (~10-20x). The logic can be found in pyCompressor.py.
+
+Options:
+When running `compreffor.compress`, options can be set using keyword arguments:
+    - nrounds (integer) -- the number of market iterations to run (default: 4)
+    - max_subrs (integer) -- limit to number of subrs per INDEX
+                             (default: 65533)
+
+With `method_python=True`, the following additional options are available:
+    - chunk_ratio (float) -- set the percentage of charstrings
+                             to be run by each process. The value must be a
+                             float between 0 < n <= 1 (default: 0.1)
+    - processes (integer) -- the number of simultaneous processes to run.
+                             Use value 1 to perform operation serially.
 
 Usage (command line):
-To use on the command line, pyCompressor.py or cxxCompressor.py must be called
-directly rather than through this file. The two offer almost identical options,
-which can be described in the following way:
->> ./pyCompressor.py -h
-...
->> ./cxxCompressor.py -h
-...
+From the command line, you can either run the package as a module,
 
-In both versions, the output goes to a file in the same directory
-as the original, but with .compressed appended just before the file
-extension. Example usage:
->> ./cxxCompressor.py /path/to/font.otf
-...
-# font written to /path/to/font.compressed.otf
+$ python -m compreffor --help
+
+Or call the `compreffor` console script installed with the package.
+Use -h/--help to list all the available options.
 """
 
 import logging

--- a/src/python/compreffor/__main__.py
+++ b/src/python/compreffor/__main__.py
@@ -1,0 +1,136 @@
+from __future__ import print_function, division, absolute_import
+import os
+import argparse
+import logging
+
+import compreffor
+from compreffor.pyCompressor import human_size
+from fontTools.ttLib import TTFont
+from fontTools.misc.loggingTools import configLogger
+
+
+def parse_arguments(args=None):
+    parser = argparse.ArgumentParser(
+        prog='compreffor',
+        description="FontTools Compreffor will take a CFF-flavored OpenType font "
+                    "and automatically detect repeated routines and generate "
+                    "subroutines to minimize the disk space needed to represent "
+                    "a font.")
+    parser.add_argument("infile", metavar="INPUT",
+                        help="path to the input font file")
+    parser.add_argument("outfile", nargs="?", metavar="OUTPUT",
+                        help="path to the compressed file (default: "
+                        "*.compressed.otf)")
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+                        help="print more messages to stdout; use it multiple "
+                        "times to increase the level of verbosity")
+    parser.add_argument("-c", "--check", action='store_true',
+                        help="verify that the outputted font is valid and "
+                             "functionally equivalent to the input")
+    parser.add_argument("-d", "--decompress", action="store_true",
+                        help="decompress source before compressing (necessary if "
+                             "there are subroutines in the source)")
+    parser.add_argument("-n", "--nrounds", type=int,
+                        help="the number of iterations to run the algorithm"
+                             " (default: 4)")
+    parser.add_argument("-m", "--max-subrs", type=int,
+                        help="limit to the number of subroutines per INDEX "
+                        " (default: 65533)")
+    parser.add_argument('--generate-cff', action='store_true',
+                        help="Also save binary CFF table data as {INPUT}.cff")
+    parser.add_argument('--py', dest="method_python", action='store_true',
+                        help="Use pure Python method, instead of C++ extension")
+    py_meth_group = parser.add_argument_group("options for pure Python method")
+    py_meth_group.add_argument("--chunk-ratio", type=float,
+                               help="specify the percentage size of the "
+                                    "job chunks used for parallel processing "
+                                    "(0 < float <= 1; default: 0.1)")
+    py_meth_group.add_argument("-p", "--processes", type=int,
+                               help="specify number  of concurrent processes to "
+                               "run. Use value 1 to perform operation serially "
+                               "(default: 12)")
+
+    options = parser.parse_args(args)
+    kwargs = vars(options)
+
+    if options.method_python:
+        if options.processes is not None and options.processes < 1:
+            parser.error('argument --processes expects positive integer > 0')
+        if (options.chunk_ratio is not None
+                and not (0 < options.chunk_ratio <= 1)):
+            parser.error('argument --chunk-ratio expects float number 0 < n <= 1')
+    else:
+        for attr in ('chunk_ratio', 'processes'):
+            if getattr(options, attr):
+                opt = attr.replace('_', '-')
+                parser.error('argument --%s can only be used with --py (pure '
+                             'Python) method' % opt)
+            else:
+                del kwargs[attr]
+    if options.outfile is None:
+        options.outfile = "%s.compressed%s" % os.path.splitext(options.infile)
+
+    return kwargs
+
+
+def main(args=None):
+    log = compreffor.log
+    timer = compreffor.timer
+    timer.reset()
+
+    options = parse_arguments(args)
+
+    # consume kwargs that are not passed on to 'compress' function
+    infile = options.pop('infile')
+    outfile = options.pop('outfile')
+    decompress = options.pop('decompress')
+    generate_cff = options.pop('generate_cff')
+    check = options.pop('check')
+    verbose = options.pop('verbose')
+
+    if verbose == 1:
+        level = logging.INFO
+    elif verbose > 1:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
+
+    configLogger(logger=log, level=level)
+
+    orig_size = os.path.getsize(infile)
+
+    font = TTFont(infile)
+
+    if decompress:
+        log.info("Decompressing font with FontTools Subsetter")
+        with timer("decompress the font"):
+            compreffor.decompress(font)
+
+    log.info("Compressing font through %s Compreffor",
+             "pure-Python" if options['method_python'] else "C++")
+
+    compreffor.compress(font, **options)
+
+    with timer("compile and save compressed font"):
+        font.save(outfile)
+
+    if generate_cff:
+        cff_file = os.path.splitext(outfile)[0] + ".cff"
+        with open(cff_file, 'wb') as f:
+            font['CFF '].cff.compile(f, None)
+        log.info("Saved CFF data to '%s'" % os.path.basename(cff_file))
+
+    if check:
+        log.info("Checking compression integrity and call depth")
+        passed = compreffor.check(infile, outfile)
+        if not passed:
+            return 1
+
+    comp_size = os.path.getsize(outfile)
+    log.info("Compressed to '%s' -- saved %s" %
+             (os.path.basename(outfile), human_size(orig_size - comp_size)))
+    log.debug("Total time: %gs", timer.time())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/compreffor/cxxCompressor.py
+++ b/src/python/compreffor/cxxCompressor.py
@@ -45,6 +45,8 @@ from fontTools.misc.py23 import BytesIO
 from fontTools.ttLib import TTFont
 
 
+__all__ = ["compreff"]
+
 # default values:
 NSUBRS_LIMIT = 65533
 SUBR_NEST_LIMIT  = 10

--- a/src/python/compreffor/cxxCompressor.py
+++ b/src/python/compreffor/cxxCompressor.py
@@ -31,18 +31,14 @@ Usage (python):
 >> font.save("/path/to/output.otf")
 """
 
-import argparse
 import array
 import struct
 import time
 import os
 from compreffor.pyCompressor import (
-    Compreffor, CandidateSubr, tokenCost, human_size)
-from compreffor.test.util import (
-    check_compression_integrity, check_call_depth)
+    Compreffor, CandidateSubr, tokenCost)
 from compreffor import _compreffor as lib
 from fontTools.misc.py23 import BytesIO
-from fontTools.ttLib import TTFont
 
 
 __all__ = ["compreff"]
@@ -51,6 +47,7 @@ __all__ = ["compreff"]
 NSUBRS_LIMIT = 65533
 SUBR_NEST_LIMIT  = 10
 
+
 class IdKeyMap(object):
     """A map that where every key's value is itself. Used
     as a map from simplified key space to actual key space
@@ -58,6 +55,7 @@ class IdKeyMap(object):
 
     def __getitem__(self, tok):
         return tok
+
 
 class SimpleCandidateSubr(CandidateSubr):
     """A reimplimentation of CandidateSubr to be more
@@ -85,6 +83,7 @@ class SimpleCandidateSubr(CandidateSubr):
     def encoding(self):
         return self._encoding
 
+
 def write_data(td):
     """Writes CharStrings and FDSelect from the TopDict td into a string
     that is easily readable."""
@@ -97,6 +96,7 @@ def write_data(td):
         fdselect = struct.pack('B', 1)
     out.write(fdselect)
     return out.getvalue()
+
 
 def get_encoding(data_buffer, subrs):
     """Read a charstring's encoding stream out of a string buffer response
@@ -114,6 +114,7 @@ def get_encoding(data_buffer, subrs):
         subrs[subr_index].freq += 1
         enc.append((insertion_pos, subrs[subr_index]))
     return enc, pos
+
 
 def read_data(td, result_string):
     """Read the output of cffCompressor.cc into Python data
@@ -147,6 +148,7 @@ def read_data(td, result_string):
 
     assert pos == len(results)
     return (subrs, glyph_encodings)
+
 
 def interpret_data(td, results):
     """Interpret the result array from a lib.compreff call to
@@ -190,6 +192,7 @@ def interpret_data(td, results):
         glyph_encodings.append(enc)
 
     return (subrs, glyph_encodings)
+
 
 def compreff(font, verbose=False, **kwargs):
     """Main function that compresses `font`, a TTFont object,
@@ -268,104 +271,3 @@ def compreff(font, verbose=False, **kwargs):
     if verbose:
         print("Finished post-processing (delta %gs)" % (time.time() - start_time))
         print("Total time: %gs" % (time.time() - full_start_time))
-
-def main(filename=None, comp_fname=None, test=False, decompress=False,
-         verbose=False, check=False, generate_cff=False, recursive=False,
-         **comp_kwargs):
-    if test:
-        pass
-
-    if filename and comp_fname == None:
-        def handle_font(font_name):
-            font = TTFont(font_name)
-
-            td = font['CFF '].cff.topDictIndex[0]
-            no_subrs = lambda fd: hasattr(fd, 'Subrs') and len(fd.Subrs) > 0
-            priv_subrs = (hasattr(td, 'FDArray') and
-                          any(no_subrs(fd) for fd in td.FDArray))
-            if len(td.GlobalSubrs) > 0 or priv_subrs:
-                print("Warning: There are subrs in %s" % font_name)
-
-            orig_size = os.path.getsize(font_name)
-
-            if decompress:
-                from fontTools import subset
-                options = subset.Options()
-                options.desubroutinize = True
-                subsetter = subset.Subsetter(options=options)
-                subsetter.populate(glyphs=font.getGlyphOrder())
-                subsetter.subset(font)
-
-            out_name = "%s.compressed%s" % os.path.splitext(font_name)
-
-            compreff(font, verbose=verbose, **comp_kwargs)
-
-            # save compressed font
-            start_time = time.time()
-            font.save(out_name)
-            if verbose:
-                print("Compiled and saved (took %gs)" % (time.time() - start_time))
-
-            if generate_cff:
-                # save CFF version
-                with open(os.path.splitext(out_name)[0] + ".cff", 'wb') as f:
-                    font['CFF '].cff.compile(f, None)
-
-            comp_size = os.path.getsize(out_name)
-            print("Compressed to %s -- saved %s" %
-                    (os.path.basename(out_name), human_size(orig_size - comp_size)))
-
-            if check:
-                check_compression_integrity(filename, out_name)
-                check_call_depth(out_name)
-
-        if recursive:
-            for root, dirs, files in os.walk(filename):
-                for fname in files:
-                    if os.path.splitext(fname)[1] == '.otf':
-                        handle_font(fname)
-        else:
-            handle_font(filename)
-
-    if check and comp_fname != None:
-        check_compression_integrity(filename, comp_fname)
-        check_call_depth(comp_fname)
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-                        description="""FontTools Compreffor will take a CFF-flavored
-                                       OpenType font and automatically detect
-                                       repeated routines and generate subroutines
-                                       to minimize the disk space needed to
-                                       represent a font.""")
-    parser.add_argument('filename', help="the path to the font file", nargs='?')
-    parser.add_argument('comp_fname', nargs='?', metavar='compressed-file',
-                        help="the path to the compressed file. if this is given"
-                             " with the -c flag, it will be checked against "
-                             " `filename`.")
-    # no tests yet :(
-    # parser.add_argument('-t', '--test', required=False, action='store_true',
-    #                     default=False, help="run test cases")
-    parser.add_argument('-v', '--verbose', required=False, action='store_true',
-                        dest='verbose', default=False)
-    parser.add_argument('-c', '--check', required=False, action='store_true',
-                        help="verify that the outputted font is valid and "
-                             "functionally equivalent to the input")
-    parser.add_argument('-d', '--decompress', required=False, action='store_true',
-                        help="decompress source before compressing (necessary if "
-                             "there are subroutines in the source)")
-    parser.add_argument('-r', '--recursive', required=False, action='store_true',
-                        default=False)
-    parser.add_argument('-n', '--nrounds', required=False, type=int,
-                        help="the number of iterations to run the algorithm"
-                             " (defaults to 4)")
-    parser.add_argument('-m', '--maxsubrs', required=False, type=int,
-                        dest='nsubrs_limit', help="limit to the number of "
-                                                  " subroutines per INDEX"
-                                                  " (defaults to 64K)")
-    parser.add_argument('--generatecff', required=False, action='store_true',
-                        dest='generate_cff', default=False)
-
-    kwargs = vars(parser.parse_args())
-
-    main(**kwargs)

--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -436,7 +436,7 @@ class Compreffor(object):
 
     def __init__(self, font, verbose=False, print_status=False, test_mode=False,
                  chunk_ratio=None, nrounds=None, single_process=None,
-                 processes=None, nsubrs_limit=None):
+                 processes=None, max_subrs=None):
         """
         Initialize the compressor.
 
@@ -449,7 +449,7 @@ class Compreffor(object):
         nrounds -- specifies the number of rounds to run
         single_process -- indicates not to parallelize
         processes -- specify the number of parallel processes
-        nsubrs_limit -- specify the limit on the number of subrs in an INDEX
+        max_subrs -- specify the limit on the number of subrs in an INDEX
         """
 
         if isinstance(font, TTFont):
@@ -472,8 +472,8 @@ class Compreffor(object):
             self.SINGLE_PROCESS = single_process
         if processes != None:
             self.PROCESSES = processes
-        if nsubrs_limit != None:
-            self.NSUBRS_LIMIT = nsubrs_limit
+        if max_subrs != None:
+            self.NSUBRS_LIMIT = max_subrs
 
     def compress(self):
         """Compress the provided font using the iterative method"""

--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -31,14 +31,18 @@ Usage (in Python):
 import itertools
 import functools
 import sys
-import time
 import multiprocessing
 import math
 from collections import deque
+import logging
 from fontTools import cffLib
 from fontTools.ttLib import TTFont
 from fontTools.misc import psCharStrings
 from fontTools.misc.py23 import range, basestring
+from compreffor import timer
+
+
+log = logging.getLogger(__name__)
 
 
 SINGLE_BYTE_OPS = set(['hstem',
@@ -69,6 +73,7 @@ SINGLE_BYTE_OPS = set(['hstem',
 
 __all__ = ["CandidateSubr", "SubstringFinder", "Compreffor", "compreff"]
 
+
 def tokenCost(token):
         """Calculate the bytecode size of a T2 Charstring token"""
 
@@ -93,6 +98,7 @@ def tokenCost(token):
         elif tp == float:
             return 5
         assert 0
+
 
 class CandidateSubr(object):
     """
@@ -130,7 +136,7 @@ class CandidateSubr(object):
     def value(self):
         """Returns the actual substring value"""
 
-        assert self.chstrings != None
+        assert self.chstrings is not None
 
         return self.chstrings[self.location[0]][self.location[1]:(self.location[1] + self.length)]
 
@@ -182,7 +188,7 @@ class CandidateSubr(object):
     def cost(self):
         """Return the size (in bytes) that the bytecode for this takes up"""
 
-        assert self.cost_map != None
+        assert self.cost_map is not None
 
         try:
             try:
@@ -215,6 +221,7 @@ class CandidateSubr(object):
     def __repr__(self):
         return "<CandidateSubr: %d x %dreps>" % (self.length, self.freq)
 
+
 class SubstringFinder(object):
     """
     This class facilitates the finding of repeated substrings
@@ -239,9 +246,9 @@ class SubstringFinder(object):
 
     __slots__ = ["suffixes", "data", "alphabet_size", "length", "substrings",
                  "rev_keymap", "glyph_set_keys", "_completed_suffixes",
-                 "cost_map", "verbose"]
+                 "cost_map"]
 
-    def __init__(self, glyph_set, verbose=False):
+    def __init__(self, glyph_set):
         self.rev_keymap = []
         self.cost_map = []
         self.data = []
@@ -251,8 +258,6 @@ class SubstringFinder(object):
         self.process_chstrings(glyph_set)
 
         self._completed_suffixes = False
-
-        self.verbose = verbose
 
     def process_chstrings(self, glyph_set):
         """Remap the charstring alphabet and put into self.data"""
@@ -301,16 +306,13 @@ class SubstringFinder(object):
         if self._completed_suffixes:
             return self.suffixes
 
-        if self.verbose:
-            print("Gettings suffixes via Python sort"); start_time = time.time()
+        with timer("get suffixes via Python sort"):
+            self.suffixes.sort(key=lambda idx: self.data[idx[0]][idx[1]:])
+            self._completed_suffixes = True
 
-        self.suffixes.sort(key=lambda idx: self.data[idx[0]][idx[1]:])
-        self._completed_suffixes = True
-
-        if self.verbose:
-            print("Took %gs" % (time.time() - start_time))
         return self.suffixes
 
+    @timer("get LCP array")
     def get_lcp(self):
         """Returns the LCP array"""
 
@@ -359,54 +361,45 @@ class SubstringFinder(object):
 
         self.get_suffixes()
 
-        if self.verbose:
-            print("Extracting substrings"); start_time = time.time()
-            print("Getting lcp"); lcp_time = time.time()
-
         lcp = self.get_lcp()
 
-        if self.verbose:
-            print("Took %gs (to get lcp array)" % (time.time() - lcp_time))
+        with timer("extract substrings"):
+            start_indices = deque()
+            self.substrings = []
 
-        start_indices = deque()
-        self.substrings = []
+            for i, min_l in enumerate(lcp):
+                # First min_l items are still the same.
 
-        for i, min_l in enumerate(lcp):
-            # First min_l items are still the same.
+                # Pop the rest from previous and account for.
+                # Note: non-branching substrings aren't included
+                # TODO: don't allow overlapping substrings into the same set
 
-            # Pop the rest from previous and account for.
-            # Note: non-branching substrings aren't included
-            # TODO: don't allow overlapping substrings into the same set
+                while start_indices and start_indices[-1][0] > min_l:
+                    l, start_idx = start_indices.pop()
+                    freq = i - start_idx
+                    if freq < min_freq:
+                        continue
 
-            while start_indices and start_indices[-1][0] > min_l:
-                l, start_idx = start_indices.pop()
-                freq = i - start_idx
-                if freq < min_freq:
-                    continue
+                    substr = CandidateSubr(
+                                           l,
+                                           self.suffixes[start_idx],
+                                           freq,
+                                           self.data,
+                                           self.cost_map)
+                    if substr.subr_saving() > 0 or not check_positive:
+                        self.substrings.append(substr)
 
-                substr = CandidateSubr(
-                                       l,
-                                       self.suffixes[start_idx],
-                                       freq,
-                                       self.data,
-                                       self.cost_map)
-                if substr.subr_saving() > 0 or not check_positive:
-                    self.substrings.append(substr)
+                if not start_indices or min_l > start_indices[-1][0]:
+                    start_indices.append((min_l, i - 1))
 
-            if not start_indices or min_l > start_indices[-1][0]:
-                start_indices.append((min_l, i - 1))
-
-        if self.verbose:
-            print("Took %gs (to extract substrings)" % (time.time() - start_time)); start_time = time.time()
-            print("%d substrings found" % len(self.substrings))
-            print("Sorting...")
-        if sort_by_length:
-            self.substrings.sort(key=lambda s: len(s))
-        else:
-            self.substrings.sort(key=lambda s: s.subr_saving(), reverse=True)
-        if self.verbose:
-            print("Took %gs (to sort)" % (time.time() - start_time))
+        log.debug("%d substrings found", len(self.substrings))
+        with timer("sort substrings"):
+            if sort_by_length:
+                self.substrings.sort(key=lambda s: len(s))
+            else:
+                self.substrings.sort(key=lambda s: s.subr_saving(), reverse=True)
         return self.substrings
+
 
 class Compreffor(object):
     """
@@ -427,26 +420,22 @@ class Compreffor(object):
     LATIN_POOL_CHUNKRATIO = 0.05
     POOL_CHUNKRATIO = 0.1
     CHUNK_CHARSET_CUTOFF = 1500
-    # NSUBRS_LIMIT = 32765 # 32K - 3
-    NSUBRS_LIMIT = 65533 # 64K - 3
+    NSUBRS_LIMIT = 65533  # 64K - 3
     SUBR_NEST_LIMIT = 10
 
-    def __init__(self, font, verbose=False, print_status=False, test_mode=False,
-                 chunk_ratio=None, nrounds=None, single_process=None,
-                 processes=None, max_subrs=None):
+    def __init__(self, font, nrounds=None, max_subrs=None,
+                 chunk_ratio=None, processes=None, test_mode=False):
         """
         Initialize the compressor.
 
         Arguments:
         font -- the TTFont to compress, must be a CFF font
-        verbose -- if True, print miscellanous info during iterations
-        print_status -- if True, print a few status updates
-        test_mode -- disables some checks (such as positive subr_saving)
-        chunk_ratio -- sets the POOL_CHUNKRATIO parameter
         nrounds -- specifies the number of rounds to run
-        single_process -- indicates not to parallelize
-        processes -- specify the number of parallel processes
         max_subrs -- specify the limit on the number of subrs in an INDEX
+        chunk_ratio -- sets the POOL_CHUNKRATIO parameter
+        processes -- specify the number of parallel processes (1 to not
+            parallelize)
+        test_mode -- disables some checks (such as positive subr_saving)
         """
 
         if isinstance(font, TTFont):
@@ -454,23 +443,29 @@ class Compreffor(object):
             assert len(font["CFF "].cff.topDictIndex) == 1
             self.font = font
         else:
-            print("Warning: non-TTFont given to Compreffor")
-        self.verbose = verbose
-        self.print_status = print_status
+            log.warning("non-TTFont given to Compreffor")
         self.test_mode = test_mode
 
-        if chunk_ratio != None:
+        if chunk_ratio is not None:
             self.POOL_CHUNKRATIO = chunk_ratio
-        elif font and len(font["CFF "].cff.topDictIndex[0].charset) < self.CHUNK_CHARSET_CUTOFF:
+        elif font and (len(font["CFF "].cff.topDictIndex[0].charset) <
+                       self.CHUNK_CHARSET_CUTOFF):
             self.POOL_CHUNKRATIO = self.LATIN_POOL_CHUNKRATIO
-        if nrounds != None:
+        if nrounds is not None:
             self.NROUNDS = nrounds
-        if single_process != None:
-            self.SINGLE_PROCESS = single_process
-        if processes != None:
-            self.PROCESSES = processes
-        if max_subrs != None:
+        if processes is not None:
+            if processes < 1:
+                raise ValueError('processes value must be > 0')
+            elif processes == 1:
+                self.SINGLE_PROCESS = True
+            else:
+                self.PROCESSES = processes
+        if max_subrs is not None:
             self.NSUBRS_LIMIT = max_subrs
+        # only print the progress in `iterative_encode` if the logger is
+        # enabled for DEBUG, and if it outputs to the console's stderr
+        self._progress = (not log.disabled and log.isEnabledFor(logging.DEBUG)
+                          and _has_stderr_handler(log))
 
     def compress(self):
         """Compress the provided font using the iterative method"""
@@ -497,6 +492,7 @@ class Compreffor(object):
         Compreffor.apply_subrs(top_dict, encoding, gsubrs, lsubrs)
 
     @staticmethod
+    @timer("apply subroutines")
     def apply_subrs(top_dict, encoding, gsubrs, lsubrs):
         multi_font = hasattr(top_dict, "FDArray")
         gbias = psCharStrings.calcSubrBias(gsubrs)
@@ -582,7 +578,7 @@ class Compreffor(object):
         """
 
         # generate substrings for marketplace
-        sf = SubstringFinder(glyph_set, verbose=self.verbose)
+        sf = SubstringFinder(glyph_set)
 
         if self.test_mode:
             substrings = sf.get_substrings(min_freq=0, check_positive=False, sort_by_length=False)
@@ -600,16 +596,16 @@ class Compreffor(object):
         if not self.SINGLE_PROCESS:
             pool = multiprocessing.Pool(processes=self.PROCESSES)
         else:
-            class DummyPool: pass
+            class DummyPool:
+                pass
             pool = DummyPool()
             pool.map = lambda f, *l, **kwargs: map(f, *l)
 
         substr_dict = {}
 
-        start_time = time.time()
+        timer.split()
 
-        if self.verbose:
-            print("glyphstrings+substrings=%d" % (len(data) + len(substrings)))
+        log.debug("glyphstrings+substrings=%d", len(data) + len(substrings))
 
         # set up dictionary with initial values
         for idx, substr in enumerate(substrings):
@@ -634,7 +630,7 @@ class Compreffor(object):
             substr_encodings = pool.map(functools.partial(optimize_charstring,
                                                           cost_map=cost_map,
                                                           substr_dict=substr_dict,
-                                                          verbose=self.verbose),
+                                                          progress=self._progress),
                                         enumerate([s.value() for s in substrings]),
                                         chunksize=csize)
 
@@ -648,7 +644,7 @@ class Compreffor(object):
             encodings = pool.map(functools.partial(optimize_charstring,
                                                    cost_map=cost_map,
                                                    substr_dict=substr_dict,
-                                                   verbose=self.verbose),
+                                                   progress=self._progress),
                                  data,
                                  chunksize=csize)
             encodings = [[(enc_item[0], substrings[enc_item[1]]) for enc_item in i["encoding"]] for i in encodings]
@@ -666,39 +662,34 @@ class Compreffor(object):
                     if substr:
                         substr._usages += 1
 
-            if self.verbose or self.print_status:
-                print("Round %d Done!" % (run_count + 1))
-                print("avg: %f" % (float(sum(substr._usages for substr in substrings)) / len(substrings)))
-                print("max: %d" % max(substr._usages for substr in substrings))
-                print("used: %d" % sum(substr._usages > 0 for substr in substrings))
+            if log.isEnabledFor(logging.INFO):
+                log.info("Round %d Done!", (run_count + 1))
+                log.info("avg: %f", (float(sum(substr._usages for substr in substrings)) / len(substrings)))
+                log.info("max: %d", max(substr._usages for substr in substrings))
+                log.info("used: %d", sum(substr._usages > 0 for substr in substrings))
 
             if run_count <= self.NROUNDS - 2 and not self.test_mode:
-                cutdown_time = time.time()
-                if run_count < self.NROUNDS - 2:
-                    bad_substrings = [s for s in substrings if s.subr_saving(use_usages=True) <= 0]
-                    substrings = [s for s in substrings if s.subr_saving(use_usages=True) > 0]
-                else:
-                    bad_substrings = [s for s in substrings if s.subr_saving(use_usages=True, true_cost=False) <= 0]
-                    substrings = [s for s in substrings if s.subr_saving(use_usages=True, true_cost=False) > 0]
+                with timer("cutdown"):
+                    if run_count < self.NROUNDS - 2:
+                        bad_substrings = [s for s in substrings if s.subr_saving(use_usages=True) <= 0]
+                        substrings = [s for s in substrings if s.subr_saving(use_usages=True) > 0]
+                    else:
+                        bad_substrings = [s for s in substrings if s.subr_saving(use_usages=True, true_cost=False) <= 0]
+                        substrings = [s for s in substrings if s.subr_saving(use_usages=True, true_cost=False) > 0]
 
-                for substr in bad_substrings:
-                    # heuristic to encourage use of called substrings:
-                    for idx, called_substr in substr._encoding:
-                        called_substr._usages += substr._usages - 1
-                    del substr_dict[substr.value()]
-                for idx, s in enumerate(substrings):
-                    s._list_idx = idx
-                if self.verbose:
-                    print("%d substrings with non-positive savings removed" % len(bad_substrings))
-                    print("(%d had positive usage)" % len([s for s in bad_substrings if s._usages > 0]))
-                    print("Took %gs to cutdown" % (time.time() - cutdown_time))
+                    for substr in bad_substrings:
+                        # heuristic to encourage use of called substrings:
+                        for idx, called_substr in substr._encoding:
+                            called_substr._usages += substr._usages - 1
+                        del substr_dict[substr.value()]
+                    for idx, s in enumerate(substrings):
+                        s._list_idx = idx
+                    if log.isEnabledFor(logging.DEBUG):
+                        log.debug("%d substrings with non-positive savings removed", len(bad_substrings))
+                        log.debug("(%d had positive usage)", len([s for s in bad_substrings if s._usages > 0]))
 
-            if self.verbose:
-                print("")
-
-        if self.verbose or self.print_status:
-            print("Finished iterative market (%gs)" % (time.time() - start_time))
-            print("%d candidate subrs found" % len(substrings))
+        log.info("Finished iterative market (%gs)", timer.split())
+        log.info("%d candidate subrs found", len(substrings))
 
         gsubrs, lsubrs = Compreffor.process_subrs(
                                             glyph_set_keys,
@@ -708,16 +699,15 @@ class Compreffor(object):
                                             substrings,
                                             rev_keymap,
                                             self.NSUBRS_LIMIT,
-                                            self.SUBR_NEST_LIMIT,
-                                            self.verbose)
+                                            self.SUBR_NEST_LIMIT)
 
         return {"glyph_encodings": dict(zip(glyph_set_keys, encodings)),
                 "lsubrs": lsubrs,
                 "gsubrs": gsubrs}
 
     @staticmethod
-    def process_subrs(glyph_set_keys, encodings, fdlen, fdselect, substrings, rev_keymap, subr_limit, nest_limit, verbose=False):
-        post_time = time.time()
+    @timer("post-process subroutines")
+    def process_subrs(glyph_set_keys, encodings, fdlen, fdselect, substrings, rev_keymap, subr_limit, nest_limit):
 
         def mark_reachable(cand_subr, fdidx):
             try:
@@ -728,7 +718,7 @@ class Compreffor(object):
 
             for it in cand_subr._encoding:
                 mark_reachable(it[1], fdidx)
-        if fdselect != None:
+        if fdselect is not None:
             for g, enc in zip(glyph_set_keys, encodings):
                 sel = fdselect(g)
                 for it in enc:
@@ -741,8 +731,7 @@ class Compreffor(object):
         subrs = [s for s in substrings if s.usages() > 0 and hasattr(s, '_fdidx') and  bool(s._fdidx) and s.subr_saving(use_usages=True, true_cost=True) > 0]
 
         bad_substrings = [s for s in substrings if s.usages() == 0 or not hasattr(s, '_fdidx') or not bool(s._fdidx) or s.subr_saving(use_usages=True, true_cost=True) <= 0]
-        if verbose:
-            print("%d substrings unused or negative saving subrs" % len(bad_substrings))
+        log.debug("%d substrings unused or negative saving subrs", len(bad_substrings))
 
         for s in bad_substrings:
             s._flatten = True
@@ -807,9 +796,8 @@ class Compreffor(object):
         gsubrs = [s for s in gsubrs if s._max_call_depth <= nest_limit]
         too_nested = len(too_nested)
 
-        if verbose:
-            print("%d substrings nested too deep" % too_nested)
-            print("%d substrings being flattened" % len(bad_substrings))
+        log.debug("%d substrings nested too deep", too_nested)
+        log.debug("%d substrings being flattened", len(bad_substrings))
 
         # reorganize to minimize call cost of most frequent subrs
         gbias = psCharStrings.calcSubrBias(gsubrs)
@@ -845,9 +833,6 @@ class Compreffor(object):
                 Compreffor.update_program(program, subr.encoding(), gbias, lbias, sel)
                 Compreffor.expand_hintmask(program)
                 subr._program = program
-
-        if verbose:
-            print("POST-TIME: %gs" % (time.time() - post_time))
 
         return (gsubrs, lsubrs)
 
@@ -925,7 +910,6 @@ class Compreffor(object):
             if tok in ("hintmask", "cntrmask"):
                 program[i:i+2] = [(program[i], program[i+1])]
 
-
     @staticmethod
     def expand_hintmask(program):
         """Expands collapsed hintmask tokens into two tokens"""
@@ -937,7 +921,23 @@ class Compreffor(object):
                 assert tok[0] in ("hintmask", "cntrmask")
                 program[i:i+1] = tok
 
-def optimize_charstring(charstring, cost_map, substr_dict, verbose):
+
+def _has_stderr_handler(logger):
+    """ Return True if any of the logger's handlers outputs to sys.stderr. """
+    c = logger
+    while c:
+        if c.handlers:
+            for h in c.handlers:
+                if hasattr(h, 'stream') and h.stream is sys.stderr:
+                    return True
+        if not c.propagate:
+            break
+        else:
+            c = c.parent
+    return False
+
+
+def optimize_charstring(charstring, cost_map, substr_dict, progress=False):
     """Optimize a charstring (encoded using keymap) using
     the substrings in substr_dict. This is the Dynamic Programming portion
     of `iterative_encode`."""
@@ -946,7 +946,6 @@ def optimize_charstring(charstring, cost_map, substr_dict, verbose):
         if type(charstring[0]) == int:
             skip_idx = charstring[0]
             charstring = charstring[1]
-            glyph_key = None
     else:
         skip_idx = None
 
@@ -993,13 +992,12 @@ def optimize_charstring(charstring, cost_map, substr_dict, verbose):
         cur_enc_substr = next_enc_substr[cur_enc_idx]
         cur_enc_idx = next_enc_idx[cur_enc_idx]
 
-        if cur_enc_substr != None:
+        if cur_enc_substr is not None:
             encoding.append((last_idx, cur_enc_substr))
-        elif cur_enc_idx - last_idx > 1 and verbose:
-            pass
 
-    if verbose:
-        sys.stdout.write("."); sys.stdout.flush()
+    if progress:
+        sys.stderr.write(".")
+        sys.stderr.flush()
     return {"encoding": encoding, "market_cost": market_cost}
 
 

--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -70,7 +70,7 @@ SINGLE_BYTE_OPS = set(['hstem',
                        'vhcurveto',
                        'hvcurveto'])
 
-__all__ = ["CandidateSubr", "SubstringFinder", "Compreffor"]
+__all__ = ["CandidateSubr", "SubstringFinder", "Compreffor", "compreff"]
 
 def tokenCost(token):
         """Calculate the bytecode size of a T2 Charstring token"""
@@ -1005,6 +1005,12 @@ def optimize_charstring(charstring, cost_map, substr_dict, verbose):
         sys.stdout.write("."); sys.stdout.flush()
     return {"encoding": encoding, "market_cost": market_cost}
 
+
+# this is here for symmetry with cxxCompressor.compreff
+
+def compreff(font, **options):
+    """ Main function that compresses `font`, a TTFont object, in place. """
+    Compreffor(font, **options).compress()
 
 
 

--- a/src/python/compreffor/test/util.py
+++ b/src/python/compreffor/test/util.py
@@ -15,11 +15,11 @@
 
 from fontTools import ttLib
 from fontTools.misc import psCharStrings
-import fontTools.subset
 
 
 def check_compression_integrity(orignal_file, compressed_file):
     """Compares two fonts to confirm they are functionally equivalent"""
+    from compreffor import decompress
 
     orig_font = ttLib.TTFont(orignal_file)
     orig_gset = orig_font.getGlyphSet()
@@ -28,13 +28,8 @@ def check_compression_integrity(orignal_file, compressed_file):
 
     assert orig_gset.keys() == comp_gset.keys()
 
-    # decompress the compressed font
-    options = fontTools.subset.Options()
-    options.desubroutinize = True
-    subsetter = fontTools.subset.Subsetter(options=options)
-    subsetter.populate(glyphs=comp_font.getGlyphOrder())
-    subsetter.subset(orig_font)
-    subsetter.subset(comp_font)
+    decompress(orig_font, make_temp=False)
+    decompress(comp_font, make_temp=False)
 
     passed = True
     for g in orig_gset.keys():

--- a/src/python/compreffor/test/util.py
+++ b/src/python/compreffor/test/util.py
@@ -64,7 +64,11 @@ def check_call_depth(compressed_file):
 
 def check_cff_call_depth(cff):
     """Checks that the Charstrings in the provided CFFFontSet
-    obey the rules for subroutine nesting."""
+    obey the rules for subroutine nesting.
+
+    Return True if the subroutine nesting level does not exceed
+    the maximum limit (10), else return False.
+    """
 
     SUBR_NESTING_LIMIT = 10
 
@@ -118,8 +122,8 @@ def check_cff_call_depth(cff):
     if track_info.max_for_all <= SUBR_NESTING_LIMIT:
         log.info("Subroutine nesting depth ok! [max nesting depth of %d]",
                  track_info.max_for_all)
-        return track_info.max_for_all
+        return True
     else:
         log.warning("Subroutine nesting depth too deep :( [max nesting depth "
                     "of %d]", track_info.max_for_all)
-        return track_info.max_for_all
+        return False


### PR DESCRIPTION
these look like lots of modifications, but they are mostly superficial; the core of the lib is unchanged.
You can read the commit messages for more details, but here are the most notable changes:

* `compreffor.Compreffor` class is no longer useful; a simple function `compreffor.compress`, with a boolean `method_python=False`, does the job. The class is kept for backward compatibility, but raises a deprecation warning on instantiation (b634553).
* the `compreffor` module now also contains a `decompress` function that uses the fonttools subsetter to desubroutinize the font (edadae8)
* the `compress` function in turn runs `decompress` on the input font if it already contains subroutines -- we can't compress an already compressed font (dd9c95a)
* we use `logging` throughout the library instead of `print` statements and `verbose` arguments; this allows clients to configure logging as they please; plus IMO code looks cleaner
* there is a single main() entry point and console script for both C++ and Python compreffors (f294691); do `compreffor --help` for the full list of options;

/cc @jamesgk @behdad @adrientetar 