### PR TITLE
Fix AttributeError in `check_cff_call_depth()`

### DIFF
--- a/src/python/compreffor/test/util.py
+++ b/src/python/compreffor/test/util.py
@@ -117,7 +117,7 @@ def check_cff_call_depth(cff):
 
     for cs in td.CharStrings.values():
         cs.decompile()
-        follow_program(cs.program, 0, cs.private.Subrs)
+        follow_program(cs.program, 0, getattr(cs.private, "Subrs", []))
 
     if track_info.max_for_all <= SUBR_NESTING_LIMIT:
         log.info("Subroutine nesting depth ok! [max nesting depth of %d]",


### PR DESCRIPTION
When compressing [FDArrayTest257.otf](https://github.com/adobe-fonts/fdarray-test/blob/master/FDArrayTest257.otf) with `--check`:

```
$ compreffor -d --check FDArrayTest257.otf
Traceback (most recent call last):
  File "/Users/mnakamura/.pyenv/versions/global-2.7.13/bin/compreffor", line 11, in <module>
    load_entry_point('compreffor==0.4.1', 'console_scripts', 'compreffor')()
  File "/Users/mnakamura/.pyenv/versions/2.7.13/envs/global-2.7.13/lib/python2.7/site-packages/compreffor/__main__.py", line 125, in main
    passed = compreffor.check(infile, outfile)
  File "/Users/mnakamura/.pyenv/versions/2.7.13/envs/global-2.7.13/lib/python2.7/site-packages/compreffor/__init__.py", line 148, in check
    rv &= check_call_depth(compressed_file)
  File "/Users/mnakamura/.pyenv/versions/2.7.13/envs/global-2.7.13/lib/python2.7/site-packages/fontTools/misc/loggingTools.py", line 372, in wrapper
    return func(*args, **kwds)
  File "/Users/mnakamura/.pyenv/versions/2.7.13/envs/global-2.7.13/lib/python2.7/site-packages/compreffor/test/util.py", line 62, in check_call_depth
    return check_cff_call_depth(f["CFF "].cff)
  File "/Users/mnakamura/.pyenv/versions/2.7.13/envs/global-2.7.13/lib/python2.7/site-packages/compreffor/test/util.py", line 120, in check_cff_call_depth
    follow_program(cs.program, 0, cs.private.Subrs)
  File "/Users/mnakamura/.pyenv/versions/2.7.13/envs/global-2.7.13/lib/python2.7/site-packages/fontTools/cffLib.py", line 1565, in __getattr__
    raise AttributeError(name)
AttributeError: Subrs
```

because Subrs operator might not appear in `cs.Private`.
This is a follow-up of the previous commit 932a60b4937ececd077736acc366cfc355037a7d.