### PR TITLE
Keep the .notdef glyph outline when decompressing

### DIFF
--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -112,6 +112,7 @@ def decompress(ttFont, **kwargs):
 
     options = subset.Options(**kwargs)
     options.desubroutinize = True
+    options.notdef_outline = True
     subsetter = subset.Subsetter(options=options)
     subsetter.populate(glyphs=tmpfont.getGlyphOrder())
     subsetter.subset(tmpfont)


### PR DESCRIPTION
The FontTools Subsetter removes it by default.