### PR TITLE
Don't use `callsubr` in global subroutines in CID-keyed CFF

### DIFF
--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -786,7 +786,13 @@ class Compreffor(object):
                     # no room for this one
                     bad_substrings.append(subr)
 
-        bad_substrings.extend([s[1] for s in subrs]) # add any leftover subrs to bad_substrings
+        bad_substrings.extend([s[1] for s in subrs])  # add any leftover subrs to bad_substrings
+
+        if fdselect is not None:
+            # CID-keyed: Avoid `callsubr` usage in global subroutines
+            bad_lsubrs = Compreffor.collect_lsubrs_called_from(gsubrs)
+            bad_substrings.extend(bad_lsubrs)
+            lsubrs = [[s for s in lsubrarr if s not in bad_lsubrs] for lsubrarr in lsubrs]
 
         for s in bad_substrings:
             s._flatten = True
@@ -844,6 +850,26 @@ class Compreffor(object):
                 subr._program = program
 
         return (gsubrs, lsubrs)
+
+    @staticmethod
+    def collect_lsubrs_called_from(gsubrs):
+        """
+        Collect local subroutines called from any entries in `gsubrs`.
+        This method returns them for after flattening
+        in order to avoid `callsubr` usage in global subroutines.
+        """
+
+        lsubrs = []
+
+        def collect(subr):
+            for _, s in subr._encoding:
+                if not s._global:
+                    lsubrs.append(s)
+                    collect(s)
+
+        for subr in gsubrs:
+            collect(subr)
+        return lsubrs
 
     @staticmethod
     def calc_nesting(subrs):

--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -855,16 +855,16 @@ class Compreffor(object):
     def collect_lsubrs_called_from(gsubrs):
         """
         Collect local subroutines called from any entries in `gsubrs`.
-        This method returns them for after flattening
+        This method returns them as a set for after flattening
         in order to avoid `callsubr` usage in global subroutines.
         """
 
-        lsubrs = []
+        lsubrs = set()
 
         def collect(subr):
             for _, s in subr._encoding:
                 if not s._global:
-                    lsubrs.append(s)
+                    lsubrs.add(s)
                     collect(s)
 
         for subr in gsubrs:

--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -218,6 +218,9 @@ class CandidateSubr(object):
             return NotImplemented
         return not(self == other)
 
+    def __hash__(self):
+        return hash((self.length, self.location))
+
     def __repr__(self):
         return "<CandidateSubr: %d x %dreps>" % (self.length, self.freq)
 

--- a/src/python/compreffor/test/pyCompressor_test.py
+++ b/src/python/compreffor/test/pyCompressor_test.py
@@ -115,6 +115,32 @@ class TestCffCompressor(unittest.TestCase):
         self.assertEqual(human_size(3565158), "3.4 MB")
         self.assertEqual(human_size(6120328397), "5.7 GB")
 
+    def test_collect_lsubrs_called_from(self):
+        """Test collecting local subrs called from any global subrs"""
+
+        g1 = pyCompressor.CandidateSubr(3, (0, 1))
+        g1._global = True
+        g2 = pyCompressor.CandidateSubr(3, (0, 1))
+        g2._global = True
+        g3 = pyCompressor.CandidateSubr(3, (0, 1))
+        g3._global = True
+        l1 = pyCompressor.CandidateSubr(3, (0, 1))
+        l1._global = False
+        l2 = pyCompressor.CandidateSubr(3, (0, 1))
+        l2._global = False
+        l3 = pyCompressor.CandidateSubr(3, (0, 1))
+        l3._global = False
+
+        g1._encoding = [(3, l1)]
+        g2._encoding = [(3, l2), (6, g3)]
+        g3._encoding = []
+        l1._encoding = []
+        l2._encoding = [(3, l3)]
+        l3._encoding = []
+
+        lsubrs = self.empty_compreffor.collect_lsubrs_called_from([g1, g2, g3])
+        self.assertSetEqual(lsubrs, {l1, l2, l3})
+
     def test_update_program_local(self):
         """Test update_program with only one replacement"""
 
@@ -244,4 +270,3 @@ class TestCffCompressor(unittest.TestCase):
         expected_value = (348, 374, 'rmoveto')
 
         self.assertEqual(self.cand_subr.value(), expected_value)
-

--- a/src/python/compreffor/test/pyCompressor_test.py
+++ b/src/python/compreffor/test/pyCompressor_test.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 from __future__ import print_function
-import unittest, random, sys
+import unittest
+import random
 from compreffor import pyCompressor
 from compreffor.test.dummy import DummyGlyphSet
-from fontTools.ttLib import TTFont
+
 
 class TestCffCompressor(unittest.TestCase):
 

--- a/src/python/compreffor/test/pyCompressor_test.py
+++ b/src/python/compreffor/test/pyCompressor_test.py
@@ -119,17 +119,17 @@ class TestCffCompressor(unittest.TestCase):
     def test_collect_lsubrs_called_from(self):
         """Test collecting local subrs called from any global subrs"""
 
-        g1 = pyCompressor.CandidateSubr(3, (0, 1))
+        g1 = pyCompressor.CandidateSubr(3, (0, 10))
         g1._global = True
-        g2 = pyCompressor.CandidateSubr(3, (0, 1))
+        g2 = pyCompressor.CandidateSubr(3, (0, 20))
         g2._global = True
-        g3 = pyCompressor.CandidateSubr(3, (0, 1))
+        g3 = pyCompressor.CandidateSubr(3, (0, 30))
         g3._global = True
-        l1 = pyCompressor.CandidateSubr(3, (0, 1))
+        l1 = pyCompressor.CandidateSubr(3, (0, 40))
         l1._global = False
-        l2 = pyCompressor.CandidateSubr(3, (0, 1))
+        l2 = pyCompressor.CandidateSubr(3, (0, 50))
         l2._global = False
-        l3 = pyCompressor.CandidateSubr(3, (0, 1))
+        l3 = pyCompressor.CandidateSubr(3, (0, 60))
         l3._global = False
 
         g1._encoding = [(3, l1)]


### PR DESCRIPTION
Fix #39

This patch is something straightforward rather than optimal, but I think it is enough.